### PR TITLE
Reduce glow effects for improved text readability

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -22,7 +22,7 @@
   background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: gradient 3s linear infinite;
-  text-shadow: 0 0 30px rgba(0, 255, 255, 0.5);
+  text-shadow: 0 0 10px rgba(0, 255, 255, 0.3);
 }
 
 .app-subtitle {
@@ -32,9 +32,8 @@
   font-weight: bold;
   margin-top: 10px;
   text-shadow:
-    0 0 10px #ffaa44,
-    0 0 20px #ffaa44,
-    0 0 30px #ffaa44;
+    0 0 5px rgba(255, 170, 68, 0.4),
+    0 0 10px rgba(255, 170, 68, 0.3);
   letter-spacing: 1px;
 }
 

--- a/src/styles/CountdownOverlay.css
+++ b/src/styles/CountdownOverlay.css
@@ -28,8 +28,8 @@
   display: block;
   line-height: 1;
   /* Use filter for better performance than multiple text-shadows */
-  filter: drop-shadow(0 0 20px #00ffff)
-          drop-shadow(0 0 40px #00ffff);
+  filter: drop-shadow(0 0 10px rgba(0, 255, 255, 0.6))
+          drop-shadow(0 0 20px rgba(0, 255, 255, 0.4));
 }
 
 /* Animations only for users who haven't disabled motion */
@@ -50,13 +50,12 @@
 
   @keyframes countdown-glow {
     0%, 100% {
-      filter: drop-shadow(0 0 20px #00ffff)
-              drop-shadow(0 0 40px #00ffff);
+      filter: drop-shadow(0 0 10px rgba(0, 255, 255, 0.6))
+              drop-shadow(0 0 20px rgba(0, 255, 255, 0.4));
     }
     50% {
-      filter: drop-shadow(0 0 30px #00ffff)
-              drop-shadow(0 0 60px #00ffff)
-              drop-shadow(0 0 90px #00ffff);
+      filter: drop-shadow(0 0 15px rgba(0, 255, 255, 0.7))
+              drop-shadow(0 0 30px rgba(0, 255, 255, 0.5));
     }
   }
 }

--- a/src/styles/EventBanner.css
+++ b/src/styles/EventBanner.css
@@ -68,7 +68,7 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+  text-shadow: 0 0 5px rgba(255, 0, 255, 0.3);
 }
 
 .audio-upload-panel-banner {
@@ -139,7 +139,7 @@
   padding: 10px;
   background: rgba(0, 255, 255, 0.1);
   border-radius: 5px;
-  text-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+  text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
 }
 
 .audio-controls-section {
@@ -263,7 +263,7 @@
   color: #00ffff;
   font-size: 14px;
   margin-bottom: 10px;
-  text-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+  text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
 }
 
 .audio-volume-slider {

--- a/src/styles/ParticipantManager.css
+++ b/src/styles/ParticipantManager.css
@@ -19,7 +19,7 @@
   -webkit-text-fill-color: transparent;
   text-align: center;
   margin: 0 0 20px 0;
-  text-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+  text-shadow: 0 0 5px rgba(255, 0, 255, 0.3);
 }
 
 .participant-input-section {
@@ -109,7 +109,7 @@
   color: #00ffff;
   font-size: 14px;
   margin-bottom: 15px;
-  text-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+  text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
 }
 
 .participant-list {

--- a/src/styles/WinnerModal.css
+++ b/src/styles/WinnerModal.css
@@ -64,7 +64,7 @@
   font-size: 36px;
   font-weight: bold;
   margin-bottom: 30px;
-  text-shadow: 0 0 20px currentColor;
+  text-shadow: 0 0 8px currentColor;
 }
 
 .winner-stats {


### PR DESCRIPTION
## Summary

Reduced excessive glow/neon effects across all UI text elements to improve readability while maintaining the cyberpunk aesthetic. Text shadows and drop shadows have been decreased by 50-60% throughout the application.

## Changes

### Text Shadow Reductions
- **App title ("Cyber Duck Race")**: 30px → 10px blur radius
- **App subtitle ("Welcome to Neo-Quckyo 2099")**: Reduced from 3 glow layers to 2, with smaller blur radii (10px/20px/30px → 5px/10px)
- **Countdown timer**: 20px/40px → 10px/20px blur with reduced opacity (0.6/0.4 instead of full opacity)
- **Event banner text**: 10px → 5px and 5px → 3px blur reductions
- **Participant manager titles**: 10px → 5px and 5px → 3px
- **Winner modal name**: 20px → 8px blur

### Files Modified
- `src/styles/App.css`
- `src/styles/CountdownOverlay.css`
- `src/styles/EventBanner.css`
- `src/styles/ParticipantManager.css`
- `src/styles/WinnerModal.css`

## Rationale

The previous glow effects were creating visual noise that made text harder to read, especially for:
- Main titles and headings
- The countdown timer during races
- Event names and labels

This update maintains the cyberpunk neon aesthetic while prioritizing text legibility.

## Test Plan

- [x] Verify app title is readable with reduced glow
- [x] Check subtitle visibility
- [x] Test countdown timer readability during race
- [x] Confirm event banner text is clear
- [x] Validate participant manager text elements
- [x] Check winner modal appearance
- [x] Ensure cyberpunk aesthetic is maintained
- [ ] Get Copilot code review feedback

## Visual Impact

All text elements now have more subtle glow effects that enhance rather than obscure the text, improving overall UX without sacrificing the app's distinctive cyberpunk style.