### PR TITLE
Add comprehensive text overflow handling to all UI panels

### DIFF
--- a/src/styles/EventBanner.css
+++ b/src/styles/EventBanner.css
@@ -140,6 +140,9 @@
   background: rgba(0, 255, 255, 0.1);
   border-radius: 5px;
   text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .audio-controls-section {

--- a/src/styles/Leaderboard.css
+++ b/src/styles/Leaderboard.css
@@ -120,4 +120,7 @@
   color: #00ffff;
   font-size: var(--font-size-lg);
   font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/styles/WinnerModal.css
+++ b/src/styles/WinnerModal.css
@@ -65,6 +65,10 @@
   font-weight: bold;
   margin-bottom: 30px;
   text-shadow: 0 0 8px currentColor;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
 }
 
 .winner-stats {
@@ -91,6 +95,9 @@
   color: #00ffff;
   font-size: var(--font-size-xl);
   font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .btn-close {


### PR DESCRIPTION
## Summary

This PR adds comprehensive text overflow handling to all remaining UI panels that were missing it. The previous PR (#13) fixed participant list and leaderboard, but the live site still showed UI expansion in other areas.

## Changes

### WinnerModal.css
- **`.winner-name` (lines 68-71)**: Added `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, and `max-width: 100%` to prevent winner name from expanding the modal
- **`.stat-value` (lines 98-100)**: Added text overflow handling for race stats displayed in winner modal

### Leaderboard.css  
- **`.stat-value` (lines 123-125)**: Added text overflow handling for first place name in stats section

### EventBanner.css
- **`.audio-file-name` (lines 143-145)**: Added text overflow handling for uploaded audio file names

## Test Plan

- [ ] Add participant with 30-character name and win a race - verify winner modal displays name with ellipsis
- [ ] Check leaderboard stats section shows first place name with ellipsis for long names
- [ ] Upload audio file with very long filename - verify it displays with ellipsis
- [ ] Verify no UI panels expand beyond their intended size with long content
- [ ] Test on live deployed version after merge

## Fixes

This resolves the issue where long participant names still caused UI expansion on the live hosted version even after PR #13.