### PR TITLE
Fix flex container overflow by adding min-width constraints

### DIFF
--- a/src/styles/Leaderboard.css
+++ b/src/styles/Leaderboard.css
@@ -78,6 +78,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .wins {

--- a/src/styles/ParticipantManager.css
+++ b/src/styles/ParticipantManager.css
@@ -191,6 +191,7 @@
   padding: 10px;
   margin-bottom: 8px;
   transition: all 0.3s ease;
+  min-width: 0;
 }
 
 .participant-item:hover {
@@ -215,6 +216,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .participant-remove-btn {


### PR DESCRIPTION
## Summary

This PR fixes the critical issue where adding long participant names would expand the UI panel horizontally, even though `text-overflow: ellipsis` was applied.

## Root Cause

Flexbox children have a default `min-width: auto`, which prevents them from shrinking below their content size. This means even with `overflow: hidden` and `text-overflow: ellipsis`, the flex container would expand to accommodate long text.

## Changes

### ParticipantManager.css
- **`.participant-item` (line 194)**: Added `min-width: 0` to prevent flex container from expanding
- **`.participant-name` (line 219)**: Added `min-width: 0` to ensure text overflow works correctly as a flex child

### Leaderboard.css
- **`.name` (line 81)**: Added `min-width: 0` for consistency with grid layout

## Test Plan

- [ ] Add participant with 30-character name
- [ ] Verify participant panel does NOT expand horizontally when participant is added to list
- [ ] Verify participant name shows ellipsis (...) for overflow
- [ ] Test on live deployed version after merge
- [ ] Verify leaderboard names also clip properly

## Fixes

This resolves the issue where the UI would expand when pressing ENTER to add a long participant name to the list, even though text clipping worked while typing.