### PR TITLE
Fix app layout flex panels to prevent horizontal expansion

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -49,6 +49,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
 }
 
 .main-panel {
@@ -56,6 +57,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
 }
 
 .side-panel {
@@ -63,6 +65,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
 }
 
 .app-footer {


### PR DESCRIPTION
## Summary

This PR fixes the ROOT CAUSE of the horizontal expansion issue. Previous PRs added `min-width: 0` to the component level, but the app layout panels themselves also needed this fix.

## Root Cause Analysis

The flexbox overflow issue existed at THREE levels:
1. ✓ `.participant-item` (fixed in PR #15)
2. ✓ `.participant-name` (fixed in PR #15)  
3. ✗ **`.left-panel`, `.main-panel`, `.side-panel`** (THIS PR)

Even though the participant components had `min-width: 0`, the `.left-panel` flex container could still expand beyond its `flex: 1` proportion, pushing the entire layout horizontally.

## Changes

### App.css
- **`.left-panel` (line 52)**: Added `min-width: 0` to prevent left column expansion
- **`.main-panel` (line 60)**: Added `min-width: 0` for consistency across layout
- **`.side-panel` (line 68)**: Added `min-width: 0` for consistency across layout

## Why This Fixes It

The `.app-content` container uses flexbox with three panels:
- `.left-panel` - `flex: 1` (25%)
- `.main-panel` - `flex: 2` (50%)
- `.side-panel` - `flex: 1` (25%)

Without `min-width: 0`, when content in `.left-panel` tries to expand (like long participant names), the panel can grow beyond its 25% allocation, breaking the layout.

## Test Plan

- [ ] Add participant with 30-character name to list
- [ ] Verify left panel does NOT expand horizontally
- [ ] Verify layout maintains 1:2:1 flex proportions
- [ ] Test on live deployed version
- [ ] Clear browser cache before testing

## Fixes

This should FINALLY resolve the persistent horizontal expansion issue on the live site.