### PR TITLE
Fix race animation to work consistently across 60Hz and 120Hz refresh rates

### DIFF
--- a/src/components/RaceTrack.jsx
+++ b/src/components/RaceTrack.jsx
@@ -213,11 +213,14 @@ const RaceTrack = ({ isRacing, onRaceEnd }) => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
     let startTime = Date.now();
+    let lastFrameTime = startTime;
     let backgroundOffset = UI_CONSTANTS.INITIAL_BACKGROUND_OFFSET;
 
     const animate = () => {
       const currentTime = Date.now();
+      const deltaTime = (currentTime - lastFrameTime) / UI_CONSTANTS.MILLISECONDS_TO_SECONDS;
       const elapsed = (currentTime - startTime) / UI_CONSTANTS.MILLISECONDS_TO_SECONDS;
+      lastFrameTime = currentTime;
 
       if (elapsed >= RACE_CONSTANTS.RACE_DURATION) {
         const winners = racePhysicsRef.current.determineWinners();
@@ -229,10 +232,11 @@ const RaceTrack = ({ isRacing, onRaceEnd }) => {
 
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-      backgroundOffset -= VISUAL_CONSTANTS.BACKGROUND_SCROLL_SPEED / UI_CONSTANTS.FRAME_RATE_DIVISOR;
+      // Time-based background scrolling: pixels per second * seconds = pixels moved
+      backgroundOffset -= VISUAL_CONSTANTS.BACKGROUND_SCROLL_SPEED * deltaTime;
       backgroundOffset = drawBackground(ctx, backgroundOffset);
 
-      const updatedDucks = racePhysicsRef.current.updateDuckPositions(elapsed);
+      const updatedDucks = racePhysicsRef.current.updateDuckPositions(elapsed, deltaTime);
       drawDucks(ctx, updatedDucks, currentTime); // Trails enabled (currentTime provided)
 
       // Update ARIA announcement for accessibility

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,7 +3,7 @@ export const RACE_CONSTANTS = {
   SPEED_CHANGE_INTERVAL: 2000,
   MIN_SPEED_MULTIPLIER: 0.4,
   MAX_SPEED_MULTIPLIER: 2.0,
-  BASE_SPEED: 100,
+  BASE_SPEED: 200, // Doubled to match original 120Hz speed with delta time implementation
   FINISH_LINE_X: 4500,
   DUCK_START_X: 80,
   DUCK_SPACING: 80,
@@ -16,7 +16,7 @@ export const RACE_CONSTANTS = {
 };
 
 export const VISUAL_CONSTANTS = {
-  BACKGROUND_SCROLL_SPEED: 300,
+  BACKGROUND_SCROLL_SPEED: 600, // Doubled to match original 120Hz speed with delta time implementation
   CANVAS_WIDTH: 800,
   CANVAS_HEIGHT: 600,
   // Background rendering

--- a/src/utils/racePhysics.js
+++ b/src/utils/racePhysics.js
@@ -86,7 +86,7 @@ export class RacePhysics {
     return this.ducks;
   }
 
-  updateDuckPositions(elapsedSeconds) {
+  updateDuckPositions(elapsedSeconds, deltaTime) {
     const now = Date.now();
 
     if (!this.lastSpeedUpdate || now - this.lastSpeedUpdate > RACE_CONSTANTS.SPEED_CHANGE_INTERVAL) {
@@ -104,7 +104,8 @@ export class RacePhysics {
 
       const effectiveSpeed = RACE_CONSTANTS.BASE_SPEED * duck.speedMultiplier * speedAdjustment;
 
-      duck.position += effectiveSpeed / PHYSICS_CONSTANTS.POSITION_UPDATE_RATE;
+      // Time-based movement: pixels per second * seconds = pixels moved
+      duck.position += effectiveSpeed * deltaTime;
 
       // Calculate displayX based on absolute position (starts at start line, moves right)
       // This ensures ducks race from left to right across the screen


### PR DESCRIPTION
## Summary

This PR fixes the refresh rate dependency issue where the race animation ran at different speeds on 60Hz vs 120Hz displays. The animation is now frame rate independent and runs at consistent speed across all refresh rates.

## Problem

The animation was frame-based (fixed pixels per frame) instead of time-based (pixels per second):
- At 120Hz: Animation ran at the correct, desired speed
- At 60Hz: Animation ran at half speed (too slow)

**Root cause:** Background and duck movement calculations divided speed by a fixed 60fps constant, making movement dependent on actual frame rate.

## Solution

Implemented delta time calculation for frame rate independence:
- Track time elapsed between frames (`deltaTime`)
- Apply time-based movement: `speed * deltaTime` instead of `speed / 60`
- Doubled speed constants (BASE_SPEED: 100→200, BACKGROUND_SCROLL_SPEED: 300→600) to maintain the original 120Hz performance as the baseline

## Changes

### RaceTrack.jsx
- Added `lastFrameTime` tracking in animation loop
- Calculate `deltaTime` each frame (time since last frame in seconds)
- Updated background scrolling: `BACKGROUND_SCROLL_SPEED * deltaTime`
- Pass `deltaTime` to `updateDuckPositions()`

### racePhysics.js
- Added `deltaTime` parameter to `updateDuckPositions()`
- Changed duck movement from `effectiveSpeed / 60` to `effectiveSpeed * deltaTime`

### constants.js
- Doubled `BASE_SPEED`: 100 → 200
- Doubled `BACKGROUND_SCROLL_SPEED`: 300 → 600

## Test Plan

- [x] Build passes without errors
- [x] Animation runs at consistent speed on both 60Hz and 120Hz displays
- [x] Background scrolling speed matches duck movement speed
- [x] No UI, CSS, or visual changes (fonts, sizing, layout all unchanged)
- [x] Race mechanics (speed variations, final sprint, stamina) work correctly

## Technical Notes

**Why double the speed constants?**
- Original frame-based calculation at 120Hz: `300 / 60 * 120 = 600 px/sec`
- New time-based calculation: `600 * deltaTime = 600 px/sec` (matches original)
- This preserves the desired 120Hz speed as the baseline across all refresh rates